### PR TITLE
feat(innerTypes): require innerTypes, discourge undeclared fields and allow types to contain themselves

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "karma-sauce-launcher": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.10",
     "rimraf": "^2.5.4",
-    "rollup": "^0.36.4",
+    "rollup": "^0.37.0",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-flow": "^1.0.1",
     "rollup-plugin-json": "^2.0.1",

--- a/src/Any.js
+++ b/src/Any.js
@@ -4,6 +4,4 @@ import { identity } from './U';
 
 const Any = x => identity(x);
 
-// Any.name = 'Any';
-
 export default Object.freeze(Any);

--- a/src/AsIs.js
+++ b/src/AsIs.js
@@ -1,5 +1,7 @@
 'use strict';
 
 import { asIsReviver } from './U';
+import Any from './Any';
 
-export default Type => Object.freeze({type: Type, reviver: asIsReviver(Type)});
+export default (Type = Any) =>
+  Object.freeze({type: Type, reviver: asIsReviver(Type)});

--- a/src/Date.js
+++ b/src/Date.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { isNothing, unsupported } from './U';
+import { isNothing, unsupported, emptyObject } from './U';
 import Base from './Base';
 
 class ModelicoDate extends Base {
@@ -11,7 +11,7 @@ class ModelicoDate extends Base {
       throw TypeError('missing date');
     }
 
-    const date = new Date(dateOrig.getTime());;
+    const date = new Date(dateOrig.getTime());
 
     this.inner = () => new Date(date.getTime());
 
@@ -43,6 +43,12 @@ class ModelicoDate extends Base {
   static metadata() {
     return Object.freeze({type: ModelicoDate, reviver: ModelicoDate.reviver});
   }
+
+  static innerTypes() {
+    return emptyObject;
+  }
 }
+
+ModelicoDate.displayName = 'ModelicoDate';
 
 export default Object.freeze(ModelicoDate);

--- a/src/Enum.js
+++ b/src/Enum.js
@@ -1,11 +1,11 @@
 'use strict';
 
-import { always, isNothing } from './U';
+import { always, isNothing, emptyObject } from './U';
 import Base from './Base';
 
 const enumeratorsReducer = (acc, code) => Object.assign(acc, { [code]: { code } });
 
-const reviverFactory = enumerators => ((k, v) => {
+const reviverFactory = enumerators => (k, v) => {
   const enumerator = enumerators[v];
 
   if (isNothing(enumerator)) {
@@ -13,22 +13,25 @@ const reviverFactory = enumerators => ((k, v) => {
   }
 
   return enumerator;
-});
+};
 
-class ModelicoEnum extends Base {
+class Enum extends Base {
   constructor(input) {
     const enumerators = Array.isArray(input) ?
       input.reduce(enumeratorsReducer, {}) :
       input;
 
-    super(ModelicoEnum, enumerators);
+    super(Enum, {});
 
     Object.getOwnPropertyNames(enumerators)
-      .forEach(enumerator => this[enumerator]().toJSON = always(enumerator));
+      .forEach(enumerator => {
+        this[enumerator] = always(enumerators[enumerator]);
+        this[enumerator]().toJSON = always(enumerator)
+      });
 
     Object.defineProperty(this, 'metadata', {
       value: always(Object.freeze({
-        type: ModelicoEnum,
+        type: Enum,
         reviver: reviverFactory(enumerators)
       })),
       enumerable: false
@@ -36,6 +39,12 @@ class ModelicoEnum extends Base {
 
     Object.freeze(this);
   }
+
+  static innerTypes() {
+    return emptyObject;
+  }
 }
 
-export default Object.freeze(ModelicoEnum);
+Enum.displayName = 'Enum';
+
+export default Object.freeze(Enum);

--- a/src/EnumMap.js
+++ b/src/EnumMap.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { reviverOrAsIs } from './U';
+import { reviverOrAsIs, emptyObject } from './U';
 import AbstractMap from './AbstractMap';
 
 const stringifyReducer = (acc, pair) => {
@@ -9,7 +9,7 @@ const stringifyReducer = (acc, pair) => {
   return acc;
 };
 
-const parseMapper = (keyMetadata, valueMetadata, object) => (enumerator => {
+const parseMapper = (keyMetadata, valueMetadata, object) => enumerator => {
   const reviveKey = reviverOrAsIs(keyMetadata);
   const key = reviveKey('', enumerator);
 
@@ -17,9 +17,9 @@ const parseMapper = (keyMetadata, valueMetadata, object) => (enumerator => {
   const val = reviveVal('', object[enumerator]);
 
   return [key, val];
-});
+};
 
-const reviverFactory = (keyMetadata, valueMetadata) => ((k, v) => {
+const reviverFactory = (keyMetadata, valueMetadata) => (k, v) => {
   if (k !== '') {
     return v;
   }
@@ -28,18 +28,18 @@ const reviverFactory = (keyMetadata, valueMetadata) => ((k, v) => {
     null :
     new Map(Object.keys(v).map(parseMapper(keyMetadata, valueMetadata, v)));
 
-  return new ModelicoEnumMap(innerMap);
-});
+  return new EnumMap(innerMap);
+};
 
-class ModelicoEnumMap extends AbstractMap {
+class EnumMap extends AbstractMap {
   constructor(innerMap) {
-    super(ModelicoEnumMap, innerMap);
+    super(EnumMap, innerMap);
 
     Object.freeze(this);
   }
 
   set(enumerator, value) {
-    return AbstractMap.set.call(this, ModelicoEnumMap, enumerator, value);
+    return AbstractMap.set.call(this, EnumMap, enumerator, value);
   }
 
   toJSON() {
@@ -47,14 +47,19 @@ class ModelicoEnumMap extends AbstractMap {
   }
 
   static fromMap(map) {
-    return new ModelicoEnumMap(map);
+    return new EnumMap(map);
   }
 
   static metadata(keyMetadata, valueMetadata) {
-    return AbstractMap.metadata(ModelicoEnumMap, reviverFactory(keyMetadata, valueMetadata));
+    return AbstractMap.metadata(EnumMap, reviverFactory(keyMetadata, valueMetadata));
+  }
+
+  static innerTypes() {
+    return emptyObject;
   }
 }
 
-ModelicoEnumMap.EMPTY = ModelicoEnumMap.fromMap(new Map([]));
+EnumMap.displayName = 'EnumMap';
+EnumMap.EMPTY = EnumMap.fromMap(new Map());
 
-export default Object.freeze(ModelicoEnumMap);
+export default Object.freeze(EnumMap);

--- a/src/List.js
+++ b/src/List.js
@@ -1,14 +1,14 @@
 'use strict';
 
-import { always, isNothing } from './U';
+import { always, isNothing, emptyObject } from './U';
 import { iterableMetadata } from './iterable';
 import Base from './Base';
 import AsIs from './AsIs';
 import Any from './Any';
 
-class ModelicoList extends Base {
+class List extends Base {
   constructor(innerListOrig) {
-    super(ModelicoList, {});
+    super(List, {});
 
     if (isNothing(innerListOrig)) {
       throw TypeError('missing list');
@@ -26,12 +26,12 @@ class ModelicoList extends Base {
     const newList = this.inner();
     newList[index] = value;
 
-    return new ModelicoList(newList);
+    return new List(newList);
   }
 
   setPath(path, value) {
     if (path.length === 0) {
-      return new ModelicoList(value);
+      return new List(value);
     }
 
     const item = this.inner()[path[0]];
@@ -48,18 +48,23 @@ class ModelicoList extends Base {
   }
 
   static fromArray(arr) {
-    return new ModelicoList(arr);
+    return new List(arr);
   }
 
   static of(...arr) {
-    return ModelicoList.fromArray(arr);
+    return List.fromArray(arr);
   }
 
   static metadata(itemMetadata) {
-    return iterableMetadata(ModelicoList, itemMetadata);
+    return iterableMetadata(List, itemMetadata);
+  }
+
+  static innerTypes() {
+    return emptyObject;
   }
 }
 
-ModelicoList.EMPTY = ModelicoList.of();
+List.displayName = 'List';
+List.EMPTY = List.of();
 
-export default Object.freeze(ModelicoList);
+export default Object.freeze(List);

--- a/src/Map.js
+++ b/src/Map.js
@@ -1,21 +1,21 @@
 'use strict';
 
-import { objToArr, reviverOrAsIs } from './U';
+import { objToArr, reviverOrAsIs, emptyObject } from './U';
 import AbstractMap from './AbstractMap';
 import AsIs from './AsIs';
 import Any from './Any';
 
-const parseMapper = (keyMetadata, valueMetadata) => (([key, value]) => {
+const parseMapper = (keyMetadata, valueMetadata) => pair => {
   const reviveKey = reviverOrAsIs(keyMetadata);
-  const revivedKey = reviveKey('', key);
+  const revivedKey = reviveKey('', pair[0]);
 
   const reviveVal = reviverOrAsIs(valueMetadata);
-  const revivedVal = reviveVal('', value);
+  const revivedVal = reviveVal('', pair[1]);
 
   return [revivedKey, revivedVal];
-});
+};
 
-const reviverFactory = (keyMetadata, valueMetadata) => ((k, v) => {
+const reviverFactory = (keyMetadata, valueMetadata) => (k, v) => {
   if (k !== '') {
     return v;
   }
@@ -25,7 +25,7 @@ const reviverFactory = (keyMetadata, valueMetadata) => ((k, v) => {
     new Map(v.map(parseMapper(keyMetadata, valueMetadata)));
 
   return new ModelicoMap(innerMap);
-});
+};
 
 class ModelicoMap extends AbstractMap {
   constructor(innerMap) {
@@ -73,8 +73,13 @@ class ModelicoMap extends AbstractMap {
   static metadata(keyMetadata, valueMetadata) {
     return AbstractMap.metadata(ModelicoMap, reviverFactory(keyMetadata, valueMetadata));
   }
+
+  static innerTypes() {
+    return emptyObject;
+  }
 }
 
+ModelicoMap.displayName = 'ModelicoMap';
 ModelicoMap.EMPTY = ModelicoMap.fromArray([]);
 
 export default Object.freeze(ModelicoMap);

--- a/src/Maybe.js
+++ b/src/Maybe.js
@@ -1,9 +1,9 @@
 'use strict';
 
-import { always, isNothing } from './U';
+import { always, isNothing, emptyObject } from './U';
 import Base from './Base';
 
-const reviverFactory = itemMetadata => ((k, v) => {
+const reviverFactory = itemMetadata => (k, v) => {
   if (k !== '') {
     return v;
   }
@@ -11,7 +11,7 @@ const reviverFactory = itemMetadata => ((k, v) => {
   const maybeValue = (v === null) ? null : itemMetadata.reviver(k, v);
 
   return new Maybe(maybeValue);
-});
+};
 
 class Nothing {
   toJSON() {
@@ -95,6 +95,13 @@ class Maybe extends Base {
   static metadata(itemMetadata) {
     return Object.freeze({type: Maybe, reviver: reviverFactory(itemMetadata)});
   }
+
+  static innerTypes() {
+    return emptyObject;
+  }
 }
+
+Maybe.displayName = 'Maybe';
+Maybe.EMPTY = Maybe.of();
 
 export default Object.freeze(Maybe);

--- a/src/Set.js
+++ b/src/Set.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { always, isNothing, unsupported } from './U';
+import { always, isNothing, unsupported, emptyObject } from './U';
 import { iterableMetadata } from './iterable';
 import Base from './Base';
 import AsIs from './AsIs';
@@ -53,8 +53,13 @@ class ModelicoSet extends Base {
   static metadata(itemMetadata) {
     return iterableMetadata(ModelicoSet, itemMetadata);
   }
+
+  static innerTypes() {
+    return emptyObject;
+  }
 }
 
+ModelicoSet.displayName = 'ModelicoSet';
 ModelicoSet.EMPTY = ModelicoSet.of();
 
 export default Object.freeze(ModelicoSet);

--- a/src/U.js
+++ b/src/U.js
@@ -2,21 +2,31 @@
 
 'use strict';
 
-const get = (field: string) => ((obj: Object) => obj[field]);
-const pipe2 = (fn1: Function, fn2: Function) => ((...args: Array<mixed>) => fn2(fn1(...args)));
+const get = (field: string) => (obj: Object) => obj[field];
+const pipe2 = (fn1: Function, fn2: Function) => (...args: Array<mixed>) => fn2(fn1(...args));
+const not = (x: boolean): boolean => !x;
 
 export const pipe = (...fns: Array<Function>) => fns.reduce(pipe2);
 export const partial = (fn: Function, ...args: Array<mixed>) => fn.bind(undefined, ...args);
 // export const is = (Ctor: Object, val: Object) => val != null && val.constructor === Ctor || val instanceof Ctor;
-export const asIsReviver = (Type: Function) => ((k: string, v: mixed) => Type(v));
-export const identity = (x: mixed) => x;
-export const always = (x: mixed) => (() => x);
-export const isNothing = (v: mixed) => v == null || v !== v;
-export const defaultTo = (d: mixed) => ((v: mixed) => isNothing(v) ? d : v );
-export const objToArr = (obj: Object) => (Object.keys(obj).map(k => [k, obj[k]]));
+export const asIsReviver = (Type: Function) => (k: string, v: mixed) => Type(v);
+export const identity = <T>(x: T): T => x;
+export const always = <T>(x: T) => (): T => x;
+export const isNothing = (v: mixed): boolean => v == null || v !== v;
+export const isSomething = pipe2(isNothing, not);
+export const defaultTo = (d: mixed) => (v: mixed) => isNothing(v) ? d : v;
+export const objToArr = (obj: Object) => Object.keys(obj).map(k => [k, obj[k]]);
 export const reviverOrAsIs = pipe2(get('reviver'), defaultTo(asIsReviver(identity)));
-export const isPlainObject = (x: mixed) => typeof x === 'object' && !!x;
-export const getInnerTypes = (Type: Function) => Type.innerTypes && Type.innerTypes() || {};
+export const isPlainObject = (x: mixed): boolean => typeof x === 'object' && !!x;
+export const emptyObject = Object.freeze({});
+
+export const getInnerTypes = (depth: number, Type: Function) => {
+  if (!Type.innerTypes) {
+    throw Error(`missing static innerTypes for ${Type.displayName || Type.name}`);
+  }
+
+  return Type.innerTypes(depth + 1, Type);
+};
 
 export const unsupported = (message: string) => {
   throw Error(message);

--- a/src/index.js
+++ b/src/index.js
@@ -5,16 +5,17 @@ import { fieldsSymbol } from './symbols';
 import { partial } from './U';
 import reviverFactory from './reviverFactory';
 
-import Maybe from './Maybe';
-
 import Base from './Base';
+
+import Maybe from './Maybe';
+import Enum from './Enum';
+
 import ModelicoMap from './Map';
 import EnumMap from './EnumMap';
 import ModelicoDate from './Date';
 import AsIs from './AsIs';
 import List from './List';
 import ModelicoSet from './Set';
-import Enum from './Enum';
 import Any from './Any';
 import proxyFactory from './proxyFactory';
 
@@ -30,14 +31,16 @@ const listNonMutators = internalNonMutators.concat(['concat', 'slice', 'filter']
 const listMutators = ['copyWithin', 'fill', 'pop', 'push', 'reverse', 'shift', 'sort', 'splice', 'unshift'];
 
 const dateNonMutators = internalNonMutators;
-const dateMutators = ['setDate', 'setFullYear', 'setHours', 'setMinutes', 'setMilliseconds', 'setMonth', 'setSeconds', 'setTime', 'setUTCDate', 'setUTCFullYear', 'setUTCHours', 'setUTCMilliseconds', 'setUTCMinutes', 'setUTCMonth', 'setUTCSeconds', 'setYear'];
+const dateMutators = ['setDate', 'setFullYear', 'setHours', 'setMinutes', 'setMilliseconds', 'setMonth', 'setSeconds',
+  'setTime', 'setUTCDate', 'setUTCFullYear', 'setUTCHours', 'setUTCMilliseconds', 'setUTCMinutes', 'setUTCMonth',
+  'setUTCSeconds', 'setYear'];
 
-const _ = function(Type) {
+const _ = function(Type, depth = 0, innerMetadata = []) {
   if (Type.metadata) {
-    return Type.metadata();
+    return Type.metadata(...innerMetadata);
   }
 
-  return Object.freeze({type: Type, reviver: reviverFactory(Type)});
+  return Object.freeze({type: Type, reviver: reviverFactory(depth, Type)});
 };
 
 const metadata = Object.freeze({
@@ -66,6 +69,7 @@ export default Object.freeze({
   Set: ModelicoSet,
   fields: x => x[fieldsSymbol](),
   fromJSON: (Type, json) => JSON.parse(json, _(Type).reviver),
+  genericsFromJSON: (Type, innerMetadata, json) => JSON.parse(json, _(Type, 0, innerMetadata).reviver),
   metadata,
   proxyMap: partial(proxyFactory, mapNonMutators, mapMutators),
   proxyList: partial(proxyFactory, listNonMutators, listMutators),

--- a/src/iterable.js
+++ b/src/iterable.js
@@ -1,17 +1,17 @@
 'use strict';
 
-import { partial } from './U';
+import { partial, reviverOrAsIs } from './U';
 
-const iterableReviverFactory = (IterableType, itemMetadata) => ((k, v) => {
+const iterableReviverFactory = (IterableType, itemMetadata) => (k, v) => {
   if (k !== '') {
     return v;
   }
 
-  const revive = partial(itemMetadata.reviver, k);
+  const revive = partial(reviverOrAsIs(itemMetadata), k);
   const iterable = (v === null) ? null : v.map(revive);
 
   return new IterableType(iterable);
-});
+};
 
 export const iterableMetadata = (IterableType, itemMetadata) => {
   return Object.freeze({

--- a/src/reviverFactory.js
+++ b/src/reviverFactory.js
@@ -2,28 +2,36 @@
 
 import { isPlainObject, reviverOrAsIs, getInnerTypes } from './U';
 
-const reviverFactory = Type => {
-  const innerTypes = getInnerTypes(Type);
+const innerTypesCache = new WeakMap();
 
-  return (k, v) => {
-    if (k !== '') {
-      return v;
+const getInnerTypesWithCache = (depth, Type) => {
+  if (!innerTypesCache.has(Type)) {
+    innerTypesCache.set(Type, getInnerTypes(depth, Type));
+  }
+
+  return innerTypesCache.get(Type);
+}
+
+const reviverFactory = (depth, Type) => (k, v) => {
+  if (k !== '') {
+    return v;
+  }
+
+  const fields = !isPlainObject(v) ? v : Object.keys(v).reduce((acc, field) => {
+    const innerTypes = getInnerTypesWithCache(depth, Type);
+
+    const metadata = innerTypes[field];
+
+    if (metadata) {
+      acc[field] = reviverOrAsIs(metadata)(k, v[field]);
+    } else {
+      acc[field] = v[field];
     }
 
-    const fields = !isPlainObject(v) ? v : Object.keys(v).reduce((acc, field) => {
-      const metadata = innerTypes[field];
+    return acc;
+  }, {});
 
-      if (metadata) {
-        acc[field] = reviverOrAsIs(metadata)(k, v[field]);
-      } else {
-        acc[field] = v[field];
-      }
-
-      return acc;
-    }, {});
-
-    return new Type(fields);
-  };
+  return new Type(fields);
 };
 
 export default reviverFactory;

--- a/test/browser/ie9_10.html
+++ b/test/browser/ie9_10.html
@@ -61,7 +61,7 @@
   <script>
     mocha.setup('bdd');
 
-    describe('Modelico', () => {
+    describe('Modelico', function() {
       describe('Modelico Dev (ES3 setup)', modelicoSpec({}, Should, Modelico));
       describe('Modelico Min (ES3 setup)', modelicoSpec({}, Should, ModelicoMin));
     });

--- a/test/cases/51-root-elements.js
+++ b/test/cases/51-root-elements.js
@@ -1,9 +1,17 @@
 'use strict';
 
 export default (should, M) => () => {
+  const { asIs } = M.metadata;
+
   class Country extends M.Base {
     constructor(code) {
       super(Country, {code});
+    }
+
+    static innerTypes() {
+      return Object.freeze({
+        code: asIs(String)
+      });
     }
   }
 

--- a/test/features/advanced.es5.js
+++ b/test/features/advanced.es5.js
@@ -10,8 +10,14 @@ export default (should, M) => () => {
   Animal.prototype = Object.create(M.Base.prototype);
 
   Animal.prototype.speak = function() {
-    var name = M.fields(this).name;
-    return (name === undefined) ? "I don't have a name" : 'My name is ' + name + '!';
+    var name = this.name();
+    return (name === '') ? "I don't have a name" : 'My name is ' + name + '!';
+  };
+
+  Animal.innerTypes = function() {
+    return Object.freeze({
+      name: asIs(String)
+    });
   };
 
   function Person(fields) {
@@ -21,8 +27,7 @@ export default (should, M) => () => {
   Person.prototype = Object.create(M.Base.prototype);
 
   Person.prototype.fullName = function() {
-    var fields = M.fields(this);
-    return [fields.givenName, fields.familyName].join(' ').trim();
+    return [this.givenName(), this.familyName()].join(' ').trim();
   };
 
   Person.innerTypes = function() {

--- a/test/features/advanced.js
+++ b/test/features/advanced.js
@@ -9,8 +9,14 @@ export default (should, M) => () => {
     }
 
     speak() {
-      const name = M.fields(this).name;
-      return (name === undefined) ? `I don't have a name` : `My name is ${name}!`;
+      const name = this.name().getOrElse('');
+      return (name === '') ? `I don't have a name` : `My name is ${name}!`;
+    }
+
+    static innerTypes() {
+      return Object.freeze({
+        name: maybe(asIs(String))
+      });
     }
   }
 
@@ -54,18 +60,20 @@ export default (should, M) => () => {
     person2.fullName().should.be.exactly('Javi Cejudo');
     person1.fullName().should.be.exactly('Javier Cejudo');
 
-    person1.pets().inner().shift().getOrElse({ speak: () => 'hello' }).speak()
+    const defaultAnimal = new Animal({});
+
+    person1.pets().inner().shift().getOrElse(defaultAnimal).speak()
       .should.be.exactly('My name is Robbie!');
 
-    person1.pets().inner().shift().getOrElse({ speak: () => 'hello' }).speak()
+    person1.pets().inner().shift().getOrElse(defaultAnimal).speak()
       .should.be.exactly('My name is Robbie!');
 
     const person3 = person1.setPath(['pets', 0, 'name'], 'Bane');
 
-    person3.pets().inner()[0].getOrElse({ name: () => 'no' }).name()
+    person3.pets().inner()[0].getOrElse(defaultAnimal).name().getOrElse('')
       .should.be.exactly('Bane');
 
-    person1.pets().inner()[0].getOrElse({ name: () => 'no' }).name()
+    person1.pets().inner()[0].getOrElse(defaultAnimal).name().getOrElse('')
       .should.be.exactly('Robbie');
   });
 };

--- a/test/features/simple.js
+++ b/test/features/simple.js
@@ -1,7 +1,7 @@
 'use strict';
 
 export default (should, M) => () => {
-  const { _ } = M.metadata;
+  const { _, asIs } = M.metadata;
 
   class Animal extends M.Base {
     constructor(fields) {
@@ -9,8 +9,14 @@ export default (should, M) => () => {
     }
 
     speak() {
-      const name = M.fields(this).name;
-      return (name === undefined) ? `I don't have a name` : `My name is ${name}!`;
+      const name = this.name();
+      return (name === '') ? `I don't have a name` : `My name is ${name}!`;
+    }
+
+    static innerTypes() {
+      return Object.freeze({
+        name: asIs(String)
+      });
     }
   }
 

--- a/test/types/Map.js
+++ b/test/types/Map.js
@@ -121,6 +121,13 @@ export default (should, M) => () => {
       should(author.lifeEvents().inner().get('wedding').inner().getFullYear()).be.exactly(2013);
     });
 
+    it('should be able to work with M.genericsFromJSON', () => {
+      const myMap = M.genericsFromJSON(M.Map, [asIs(Number), asIs(String)], '[[1, "10"], [2, "20"], [3, "30"]]');
+
+      myMap.inner().get(2)
+        .should.be.exactly('20');
+    });
+
     it('should not support null (wrap with Maybe)', () => {
       (() => JSON.parse(
         'null',

--- a/test/types/Maybe.js
+++ b/test/types/Maybe.js
@@ -19,14 +19,6 @@ export default (should, M) => () => {
         .should.be.exactly('Javi');
     });
 
-    it('should set fields recursively returning a new Maybe', () => {
-      const maybe1 = JSON.parse(authorJson, maybe(_(Person)).reviver);
-      const maybe2 = maybe1.set('givenName', 'Javi');
-
-      maybe2.inner().get().givenName()
-        .should.be.exactly('Javi');
-    });
-
     it('should not throw upon setting if empty', () => {
       const maybe = M.Maybe.of(null);
 

--- a/test/types/fixtures/Animal.js
+++ b/test/types/fixtures/Animal.js
@@ -1,6 +1,8 @@
 'use strict';
 
 export default M => {
+  const { asIs } = M.metadata;
+
   class Animal extends M.Base {
     constructor(fields) {
       super(Animal, fields);
@@ -8,6 +10,12 @@ export default M => {
 
     speak() {
       return 'hello';
+    }
+
+    static innerTypes() {
+      return Object.freeze({
+        name: asIs(String)
+      });
     }
   }
 

--- a/test/types/fixtures/Friend.js
+++ b/test/types/fixtures/Friend.js
@@ -1,0 +1,25 @@
+'use strict';
+
+export default M => {
+  const { _, asIs, maybe } = M.metadata;
+
+  class Friend extends M.Base {
+    constructor(fields) {
+      super(Friend, fields);
+    }
+
+    static innerTypes(depth) {
+      return Object.freeze({
+        name: asIs(String),
+        bestFriend: maybe(_(Friend, depth))
+      });
+    }
+  }
+
+  Friend.EMPTY = new Friend({
+    name: '',
+    bestFriend: M.Maybe.EMPTY
+  });
+
+  return Object.freeze(Friend);
+};

--- a/test/types/fixtures/nested/City.js
+++ b/test/types/fixtures/nested/City.js
@@ -13,10 +13,10 @@ export default (M, Region) => {
       return Object.freeze(this);
     }
 
-    static innerTypes() {
+    static innerTypes(depth) {
       return Object.freeze({
         name: asIs(String),
-        country: _(Country)
+        country: _(Country, depth)
       });
     }
   }

--- a/test/types/fixtures/nested/Country.js
+++ b/test/types/fixtures/nested/Country.js
@@ -10,11 +10,11 @@ export default (M, Region) => {
       return Object.freeze(this);
     }
 
-    static innerTypes() {
+    static innerTypes(depth) {
       return Object.freeze({
         name: asIs(String),
         code: asIs(String),
-        region: _(Region)
+        region: _(Region, depth)
       });
     }
   }


### PR DESCRIPTION
Even though no accessors are created, the fields will still be stringified to ensure
that the stringified result matches the originally parsed JSON